### PR TITLE
fix copy error

### DIFF
--- a/src/SourceRepositoryTypes/GithubRepositoryType.php
+++ b/src/SourceRepositoryTypes/GithubRepositoryType.php
@@ -148,7 +148,8 @@ class GithubRepositoryType extends AbstractRepositoryType implements SourceRepos
 
             // Now move all the files left in the main directory
             collect(File::allFiles($sourcePath, true))->each(function ($file) { /* @var \SplFileInfo $file */
-                File::copy($file->getRealPath(), base_path($file->getFilename()));
+                if ($file->getRealPath())
+                    File::copy($file->getRealPath(), base_path($file->getFilename()));
             });
 
             File::deleteDirectory($sourcePath);


### PR DESCRIPTION
sometimes, certain file does not delete and $file->getRealPath() return false. So we need to put some check before copy to avoid argument pass into copy() is empty error.