### PR TITLE
Resolves issue where only one of the pre/post update commands is executed

### DIFF
--- a/src/SourceRepository.php
+++ b/src/SourceRepository.php
@@ -110,7 +110,7 @@ class SourceRepository implements SourceRepositoryTypeContract
      */
     protected function preUpdateArtisanCommands()
     {
-        collect(config('self-update.artisan_commands.pre_update'))->every(function ($commandParams, $commandKey) {
+        collect(config('self-update.artisan_commands.pre_update'))->each(function ($commandParams, $commandKey) {
             Artisan::call($commandKey, $commandParams['params']);
         });
     }
@@ -120,7 +120,7 @@ class SourceRepository implements SourceRepositoryTypeContract
      */
     protected function postUpdateArtisanCommands()
     {
-        collect(config('self-update.artisan_commands.post_update'))->every(function ($commandParams, $commandKey) {
+        collect(config('self-update.artisan_commands.post_update'))->each(function ($commandParams, $commandKey) {
             Artisan::call($commandKey, $commandParams['params']);
         });
     }


### PR DESCRIPTION
I'm using Laravel 5.8, Only one command is executed because of this

![image](https://user-images.githubusercontent.com/3615746/64486485-5ff38900-d260-11e9-87e2-35eb6c33014b.png)
