### PR TITLE
#63 laravel 6 comp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 branches:
   except:

--- a/composer.json
+++ b/composer.json
@@ -48,9 +48,9 @@
     }
   },
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "ext-zip": "*",
-    "illuminate/support": "5.*",
+    "laravel/framework": "^5.8|6.*",
     "guzzlehttp/guzzle": "6.*"
   },
   "require-dev": {


### PR DESCRIPTION
Make Laravel 6 compatible:

* Drop php 7.1 support
* Depend on Laravel framework version instead of illuminate/support