### PR TITLE
Check correct commit version

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,34 +145,31 @@ a `private_access_token` field, where you can set the token.
 ## Usage
 To start an update process, i. e. in a controller, just use:
 ```php
-public function update()
-{
-    // This downloads and install the latest version of your repo
-    Updater::update();
-    
-    // Just download the source and do the actual update elsewhere
-    Updater::fetch();
-    
-    // Check if a new version is available and pass current version
-    Updater::isNewVersionAvailable('1.2');
-}
+Route::get('/', function (\Codedge\Updater\UpdaterManager $updater) {
+
+    // Check if new version is available
+    if($updater->source()->isNewVersionAvailable()) {
+
+        // Get the current installed version
+        $updater->source()->getVersionInstalled();
+
+        // Get the new version available
+        $updater->source()->getVersionAvailable();
+
+        // Run the update process
+        $updater->source()->update();
+        
+    } else {
+        echo "No new version available.";
+    }
+
+});
 ```
 
-Of course you can inject the _updater_ via method injection:
-```php
-public function update(UpdaterManager $updater)
-{
+**IMPORTANT**:  
+You're responsible to set the current version installed, either in the config file or better via the env variable `SELF_UPDATER_VERSION_INSTALLED`.
 
-    $updater->update(); // Same as above
-    
-    // .. and shorthand for this:
-    $updater->source()->update;
-    
-    $updater->fetch(); // Same as above...
-}
-```
-
-**Note:** Currently the fetching of the source is a _synchronous_ process.
+Currently the fetching of the source is a _synchronous_ process.
 It is not run in background.
 
 ### Using Github

--- a/src/SourceRepositoryTypes/GithubRepositoryTypes/GithubBranchType.php
+++ b/src/SourceRepositoryTypes/GithubRepositoryTypes/GithubBranchType.php
@@ -51,7 +51,7 @@ final class GithubBranchType extends GithubRepositoryType implements GithubRepos
 
         $release = $this->selectRelease($releaseCollection, $version);
 
-        $storageFolder = $this->storagePath.$release->commit->author->date . '-' . now()->timestamp;
+        $storageFolder = $this->storagePath.$release->commit->author->date.'-'.now()->timestamp;
         $storageFilename = $storageFolder.'.zip';
 
         if (! $this->isSourceAlreadyFetched($release->commit->author->date)) {
@@ -66,7 +66,7 @@ final class GithubBranchType extends GithubRepositoryType implements GithubRepos
         $release = $collection->first();
 
         if (! empty($version)) {
-            if($collection->contains('commit.author.date', $version)) {
+            if ($collection->contains('commit.author.date', $version)) {
                 $release = $collection->where('commit.author.date', $version)->first();
             } else {
                 Log::info('No release for version "'.$version.'" found. Selecting latest.');


### PR DESCRIPTION
Fixes a problem from #79 where the version that is written inside the version file is not the one that is compared against when selecting a new release.