### PR TITLE
Prevent from downgrades

### DIFF
--- a/src/Contracts/SourceRepositoryTypeContract.php
+++ b/src/Contracts/SourceRepositoryTypeContract.php
@@ -22,7 +22,7 @@ interface SourceRepositoryTypeContract
      *
      * @return bool
      */
-    public function update(string $version = ''): bool;
+    public function update(string $version): bool;
 
     /**
      * Check repository if a newer version than the installed one is available.

--- a/src/SourceRepositoryTypes/HttpRepositoryType.php
+++ b/src/SourceRepositoryTypes/HttpRepositoryType.php
@@ -143,14 +143,12 @@ class HttpRepositoryType extends AbstractRepositoryType implements SourceReposit
      *
      * @return bool
      */
-    public function update($version = ''): bool
+    public function update($version): bool
     {
         $this->setPathToUpdate(base_path(), $this->config['exclude_folders']);
 
         if ($this->hasCorrectPermissionForUpdate()) {
-            if (empty($version)) {
-                $version = $this->getVersionAvailable();
-            }
+
             $sourcePath = $this->config['download_path'].DIRECTORY_SEPARATOR.$this->prepend.$version.$this->append;
 
             // Move all directories first

--- a/src/SourceRepositoryTypes/HttpRepositoryType.php
+++ b/src/SourceRepositoryTypes/HttpRepositoryType.php
@@ -148,7 +148,6 @@ class HttpRepositoryType extends AbstractRepositoryType implements SourceReposit
         $this->setPathToUpdate(base_path(), $this->config['exclude_folders']);
 
         if ($this->hasCorrectPermissionForUpdate()) {
-
             $sourcePath = $this->config['download_path'].DIRECTORY_SEPARATOR.$this->prepend.$version.$this->append;
 
             // Move all directories first


### PR DESCRIPTION
If version parameter is not set, the autodetection by $this->getVersionAvailable() will lead to downgrades if a older versions remain in repo. I would add a version check or disable calls to update() without a valid version.