### PR TITLE
Correction on createReleaseFolder

### DIFF
--- a/src/Models/Release.php
+++ b/src/Models/Release.php
@@ -266,7 +266,8 @@ final class Release
 
             $this->filesystem->moveDirectory(
                 createFolderFromFile($this->getStoragePath()).now()->toDateString(),
-                createFolderFromFile($this->getStoragePath())
+                createFolderFromFile($this->getStoragePath()),
+                true
             );
         }
 


### PR DESCRIPTION
When downloading the compressed file from Github, it is unzipped correctly in folders v1 and v12020-06-12, but when moving the content from v12020-06-12 to folder v1 does not work, folder v1 is empty. I've added a line to force overwriting of the folder. With this change it works correctly, the files are moved to v1 and the update process completes successfully.

I am using Windows 10 with PHP 7.3 and Apache 2.4.41.