### PR TITLE
Update GithubRepositoryType.php

### DIFF
--- a/src/SourceRepositoryTypes/GithubRepositoryType.php
+++ b/src/SourceRepositoryTypes/GithubRepositoryType.php
@@ -47,6 +47,8 @@ class GithubRepositoryType
     {
         $this->config = $config;
         $this->updateExecutor = $updateExecutor;
+
+        $this->setAccessToken($this->config['private_access_token']);
     }
 
     public function create(): SourceRepositoryTypeContract


### PR DESCRIPTION
In relation to problem #115 it seems that this was not using the github private access token. 

I have added a line to set the configured token in the GithubRepositoryType constructor, this works fine.