### PR TITLE
Improve performance of permission checking

### DIFF
--- a/src/Models/UpdateExecutor.php
+++ b/src/Models/UpdateExecutor.php
@@ -52,7 +52,7 @@ final class UpdateExecutor
      */
     public function run(Release $release): bool
     {
-        if (checkPermissions((new Finder())->in($this->basePath))) {
+        if (checkPermissions($this->basePath)) {
             $releaseFolder = createFolderFromFile($release->getStoragePath());
 
             // Move all directories first

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -28,17 +28,22 @@ if (! \function_exists('checkPermissions')) {
      *
      * @return bool
      */
-    function checkPermissions(Finder $directory): bool
+    function checkPermissions(string $directory): bool
     {
-        $checkPermission = true;
 
-        collect($directory->getIterator())->each(function (SplFileInfo $file) use (&$checkPermission) {
-            if ($file->isWritable() === false) {
-                $checkPermission = false;
+        $directoryIterator = new \RecursiveDirectoryIterator($directory);
+
+        foreach(new \RecursiveIteratorIterator($directoryIterator) as $file) {
+
+            if(is_file($file) && !is_writable($file)) {
+
+                return false;
+
             }
-        });
 
-        return $checkPermission;
+        }
+
+        return true;
     }
 }
 


### PR DESCRIPTION
In projects with very large directories/files the current implementation fails silently probably due to OOM.

The following PR improves the performance of the checkPermissions() method by returning early on the first file occurence which is not writable, and also by using native iterator instead of Symfony component.