### PR TITLE
fix missing github branch-based archiveUrl host

### DIFF
--- a/src/SourceRepositoryTypes/GithubRepositoryTypes/GithubBranchType.php
+++ b/src/SourceRepositoryTypes/GithubRepositoryTypes/GithubBranchType.php
@@ -111,7 +111,8 @@ final class GithubBranchType extends GithubRepositoryType implements SourceRepos
 
     private function generateArchiveUrl(string $name): string
     {
-        return DIRECTORY_SEPARATOR.'repos'
+        return self::BASE_URL
+               .DIRECTORY_SEPARATOR.'repos'
                .DIRECTORY_SEPARATOR.$this->config['repository_vendor']
                .DIRECTORY_SEPARATOR.$this->config['repository_name']
                .DIRECTORY_SEPARATOR.'zipball'


### PR DESCRIPTION
The github host was missing if using branch-based releases.

Fixes #421 