### PR TITLE
Include path in HTTP source repository type URI

### DIFF
--- a/src/SourceRepositoryTypes/HttpRepositoryType.php
+++ b/src/SourceRepositoryTypes/HttpRepositoryType.php
@@ -203,7 +203,7 @@ class HttpRepositoryType implements SourceRepositoryTypeContract
         $releaseVersions = array_combine($files[2], $files[1]);
 
         $uri = Uri::createFromString($this->config['repository_url']);
-        $baseUrl = $uri->getScheme().'://'.$uri->getHost();
+        $baseUrl = $uri->getScheme().'://'.$uri->getHost().$uri->getPath();
 
         $releases = collect($releaseVersions)->map(function ($item, $key) use ($baseUrl) {
             $uri = Uri::createFromString($item);


### PR DESCRIPTION
This fix allows HTTP source repository type URL in the form of `"https://example.com/updates/subfolder"`. Before the fix the update URL would become (e.g. for app-v1.2.3.zip) `"https://example.com/app-v1.2.3.zip"` when it should be `"https://example.com/updates/subfolder/app-v1.2.3.zip"`.

In case of a URL without a path, an empty string is returned:

URL: `https://example.com/updates/v2`
Scheme: `string(5) "https"`
Host: `string(11) "example.com"`
Path: `string(11) "/updates/v2"`
baseUrl: `https://example.com/updates/v2`


URL: `https://example.com`
Scheme: `string(5) "https"`
Host: `string(11) "example.com"`
Path: `string(0) ""`
baseUrl: `https://example.com`
